### PR TITLE
Fix backend endpoint dependencies and correct persisted state plugin

### DIFF
--- a/backend/GlobalUsings.cs
+++ b/backend/GlobalUsings.cs
@@ -1,0 +1,2 @@
+global using Microsoft.AspNetCore.Http;
+global using Microsoft.AspNetCore.Routing;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@headlessui/vue": "^1.7.17",
     "@heroicons/vue": "^2.1.5",
-    "@pinia/plugin-persistedstate": "^3.2.0",
+    "pinia-plugin-persistedstate": "^3.2.0",
     "@tanstack/vue-query": "^5.50.0",
     "axios": "^1.6.8",
     "localforage": "^1.10.0",

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,6 +1,6 @@
 import { createApp } from 'vue';
 import { createPinia } from 'pinia';
-import piniaPersist from '@pinia/plugin-persistedstate';
+import piniaPersistedstate from 'pinia-plugin-persistedstate';
 import { createHead } from '@vueuse/head';
 import App from './App.vue';
 import router from './router';
@@ -12,7 +12,7 @@ import { configureApiClient } from './services/httpClient';
 const app = createApp(App);
 
 const pinia = createPinia();
-pinia.use(piniaPersist);
+pinia.use(piniaPersistedstate);
 
 const i18n = createI18n({
   legacy: false,


### PR DESCRIPTION
## Summary
- add global ASP.NET Core usings so endpoint extensions compile cleanly
- switch the persisted state plugin dependency to the published Pinia package and update its import

## Testing
- npm install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68df27d2ad28832993240757b3533964