### PR TITLE
Fix DI constructors for .NET 7 compatibility

### DIFF
--- a/backend/Data/SqlConnectionFactory.cs
+++ b/backend/Data/SqlConnectionFactory.cs
@@ -4,10 +4,15 @@ using System.Data;
 
 namespace FerreteriaPOS.Data;
 
-public sealed class SqlConnectionFactory(IConfiguration configuration) : ISqlConnectionFactory
+public sealed class SqlConnectionFactory : ISqlConnectionFactory
 {
-    private readonly string _connectionString = configuration.GetConnectionString("Default") ??
-        throw new InvalidOperationException("Connection string 'Default' not found.");
+    private readonly string _connectionString;
+
+    public SqlConnectionFactory(IConfiguration configuration)
+    {
+        _connectionString = configuration.GetConnectionString("Default") ??
+            throw new InvalidOperationException("Connection string 'Default' not found.");
+    }
 
     public async Task<IDbConnection> CreateConnectionAsync(CancellationToken cancellationToken = default)
     {


### PR DESCRIPTION
## Summary
- replace the use of primary constructors in SqlConnectionFactory and StoredProcedureExecutor with explicit constructors
- ensure dependencies are stored in private fields so the services compile against the .NET 7 language version

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df29b1a1208329957f179266d86b12