### PR TITLE
Exclude test sources from API project

### DIFF
--- a/backend/Data/SqlConnectionFactory.cs
+++ b/backend/Data/SqlConnectionFactory.cs
@@ -4,10 +4,15 @@ using System.Data;
 
 namespace FerreteriaPOS.Data;
 
-public sealed class SqlConnectionFactory(IConfiguration configuration) : ISqlConnectionFactory
+public sealed class SqlConnectionFactory : ISqlConnectionFactory
 {
-    private readonly string _connectionString = configuration.GetConnectionString("Default") ??
-        throw new InvalidOperationException("Connection string 'Default' not found.");
+    private readonly string _connectionString;
+
+    public SqlConnectionFactory(IConfiguration configuration)
+    {
+        _connectionString = configuration.GetConnectionString("Default") ??
+            throw new InvalidOperationException("Connection string 'Default' not found.");
+    }
 
     public async Task<IDbConnection> CreateConnectionAsync(CancellationToken cancellationToken = default)
     {

--- a/backend/FerreteriaPOS.Api.csproj
+++ b/backend/FerreteriaPOS.Api.csproj
@@ -14,4 +14,10 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="AspNetCoreRateLimit" Version="5.0.0" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**\*" />
+    <None Remove="tests\**\*" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- exclude the backend/tests sources from the FerreteriaPOS.Api project so the API build no longer tries to compile xUnit tests
- prevent test-only files from contributing duplicate TargetFramework attributes during the API build

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df29b1a1208329957f179266d86b12