### PR TITLE
Use client rate limiting middleware and fix test build

### DIFF
--- a/backend/Data/SqlConnectionFactory.cs
+++ b/backend/Data/SqlConnectionFactory.cs
@@ -4,10 +4,15 @@ using System.Data;
 
 namespace FerreteriaPOS.Data;
 
-public sealed class SqlConnectionFactory(IConfiguration configuration) : ISqlConnectionFactory
+public sealed class SqlConnectionFactory : ISqlConnectionFactory
 {
-    private readonly string _connectionString = configuration.GetConnectionString("Default") ??
-        throw new InvalidOperationException("Connection string 'Default' not found.");
+    private readonly string _connectionString;
+
+    public SqlConnectionFactory(IConfiguration configuration)
+    {
+        _connectionString = configuration.GetConnectionString("Default") ??
+            throw new InvalidOperationException("Connection string 'Default' not found.");
+    }
 
     public async Task<IDbConnection> CreateConnectionAsync(CancellationToken cancellationToken = default)
     {

--- a/backend/FerreteriaPOS.Api.csproj
+++ b/backend/FerreteriaPOS.Api.csproj
@@ -14,4 +14,10 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="AspNetCoreRateLimit" Version="5.0.0" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**\*" />
+    <None Remove="tests\**\*" />
+  </ItemGroup>
 </Project>

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -103,7 +103,7 @@ app.UseForwardedHeaders(new ForwardedHeadersOptions
 
 app.UseCors("AllowSpecificOrigins");
 
-app.UseRateLimiting();
+app.UseClientRateLimiting();
 
 app.UseSwagger();
 app.UseSwaggerUI();

--- a/backend/tests/FerreteriaPOS.Tests.csproj
+++ b/backend/tests/FerreteriaPOS.Tests.csproj
@@ -10,6 +10,6 @@
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../FerreteriaPOS.Api.csproj" />
+    <Compile Include="../Models/Resultado.cs" Link="Models/Resultado.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- switch the pipeline to use `UseClientRateLimiting` so the configured client rate limiter middleware is applied
- include the shared `Resultado` model directly in the test project so it no longer depends on the API build output

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68df29b1a1208329957f179266d86b12