### PR TITLE
Add memory cache registration for rate limiting

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -70,6 +70,7 @@ builder.Services.AddSwaggerGen(options =>
 
 builder.Services.Configure<ClientRateLimitOptions>(builder.Configuration.GetSection("RateLimiting"));
 builder.Services.Configure<ClientRateLimitPolicies>(builder.Configuration.GetSection("RateLimitingPolicies"));
+builder.Services.AddMemoryCache();
 builder.Services.AddInMemoryRateLimiting();
 builder.Services.AddSingleton<IRateLimitConfiguration, RateLimitConfiguration>();
 


### PR DESCRIPTION
## Summary
- register the memory cache service required by AspNetCoreRateLimit
- ensure rate limiting stores can resolve IMemoryCache during startup

## Testing
- dotnet build *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df2ea801748329b3efa32795063485