### PR TITLE
Stabilize frontend alias resolution

### DIFF
--- a/frontend/src/components/modals/ConfirmDialog.vue
+++ b/frontend/src/components/modals/ConfirmDialog.vue
@@ -1,7 +1,7 @@
 <template>
-  <FormDialog :open="open" :title="title" @close="$emit('close')" @submit="$emit('confirm')">
+  <FormDialog :open="props.open" :title="props.title" @close="$emit('close')" @submit="$emit('confirm')">
     <p class="text-sm text-slate-600 dark:text-slate-300">
-      {{ message }}
+      {{ props.message }}
     </p>
   </FormDialog>
 </template>
@@ -9,7 +9,12 @@
 <script setup lang="ts">
 import FormDialog from './FormDialog.vue';
 
-defineProps<{ open: boolean; title?: string; message: string }>();
+const props = withDefaults(
+  defineProps<{ open: boolean; title?: string; message: string }>(),
+  {
+    title: ''
+  }
+);
 
 defineEmits<{ (e: 'close'): void; (e: 'confirm'): void }>();
 </script>

--- a/frontend/src/layouts/AppShell.vue
+++ b/frontend/src/layouts/AppShell.vue
@@ -52,7 +52,7 @@ const filteredNavItems = computed(() =>
   navItems.filter((item) => !item.roles || item.roles.some((role) => store.hasRole(role)))
 );
 
-const title = computed(() => route.meta?.title ?? 'Ferretería POS');
+const title = computed(() => (route.meta?.title as string | undefined) ?? 'Ferretería POS');
 const isLoading = computed(() => store.isLoading);
 
 const toggleDrawer = () => {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -10,9 +10,9 @@
     "esModuleInterop": true,
     "noEmit": true,
     "types": ["vite/client", "@types/node"],
-    "baseUrl": "./src",
+    "baseUrl": "./",
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["src/*"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue", "tests/**/*.ts"],

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -3,7 +3,11 @@
     "composite": true,
     "module": "ESNext",
     "moduleResolution": "Node",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["vite.config.ts"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,15 +1,23 @@
+import { fileURLToPath, URL } from 'node:url';
 import { defineConfig, loadEnv } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import vueJsx from '@vitejs/plugin-vue-jsx';
 import { VitePWA } from 'vite-plugin-pwa';
 
+const projectRootDir = fileURLToPath(new URL('./', import.meta.url));
+const srcDir = fileURLToPath(new URL('./src', import.meta.url));
+
 export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), '');
+  const env = loadEnv(mode, projectRootDir, '');
 
   return {
+    root: projectRootDir,
     server: {
       port: 5173,
       host: true
+    },
+    resolve: {
+      alias: [{ find: '@', replacement: srcDir }]
     },
     plugins: [
       vue(),


### PR DESCRIPTION
## Summary
- derive absolute frontend root and src paths in the Vite config so the `@` alias works consistently across environments
- align the TypeScript configs with the same base URL and `@/*` mapping for editor and tooling support

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df2fa70c208329821eb1909a7c5291